### PR TITLE
Add more hints about cross compiling

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -119,8 +119,11 @@ Cross-compiling for Tarragon
 ============================
 
 Another way to integrate custom applications into the firmware image is to cross-compile the application
-for Tarragon and include it in the image. A pre-requisite for this is to have the latest firmware image,
-preferably a developer build.
+for Tarragon and include it in the image. A pre-requisite for this is to have the latest firmware image
+as a developer build. Always keep in mind, if you want to build a new EVerest module it must be
+compatible to the EVerest release within the firmware. Please have a look at the official
+`EVerest documentation <https://everest.github.io/nightly/dev_tools/edm.html#setting-up-and-updating-a-workspace>`_,
+how to checkout a dedicated EVerest release.
 
 #. On an Ubuntu or Debian-based Linux distribution, install the cross-compilers for Tarragon.
 
@@ -161,7 +164,7 @@ preferably a developer build.
       set(CMAKE_SYSTEM_PROCESSOR arm)
 
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-psabi" CACHE STRING "" FORCE )
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi"  CACHE STRING "" FORCE )
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi" CACHE STRING "" FORCE )
 
       if(CMAKE_BUILD_TYPE MATCHES Debug)
           # Debug flags

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -104,6 +104,16 @@ Then copy the device model database onto the Charge Control C (adapt IP address 
 Finally make sure the DeviceModelDatabasePath in your global YAML configuration points to
 /var/lib/everest/ocpp201/device_model_storage.db and then restart EVerest on the Charge Control C.
 
+I tried to compile chargebyte's Hardware EVerest Modules, but it fails to build. How can it fix this?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The EVerest mainline development is very dynamic and doesn't guarantee any
+stable API along the EVerest modules. So after almost every EVerest release,
+chargebyte needs to adapt their modules to the latest API changes.
+
+Please have a look at the `compatibility matrix <https://github.com/chargebyte/everest-chargebyte/blob/main/README.md>`_
+to see which EVerest release works with which chargebyte EVerest Modules release.
+
 
 I would like to implement a custom Modbus device in EVerest. Where should I start?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Cross compiling EVerest and external modules has pitfalls. So add some hints for developers to avoid them.