### PR TITLE
Add link check workflow for index

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,20 @@
+name: Link check
+
+# Allow to trigger on pull requests and manually via Github Actions
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    # Use Ubuntu as environment
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    # This external action cares about all the sphinx stuff
+    - uses: ammaraskar/sphinx-action@4.3.2
+      with:
+        build-command: "sphinx-build -b linkcheck source/ build/"
+        docs-folder: "docs/"
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,3 +31,8 @@ html_css_files = [
 ]
 html_show_sourcelink = False
 html_use_index = False
+
+# -- Options for the linkcheck builder ---------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
+
+linkcheck_anchors = False


### PR DESCRIPTION
This adds a sphinxbuild link check workflow for the index page, which triggers on every pull request or could be manually triggered.