### PR TITLE
README: point to correct branches and to rendered docs from `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ This documentation contains all necessary information and guides for the use and
 >
 > Please refer to either:
 >
-> - **Charge Control C** at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_control_c
-> - **Charge SOM** at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_som
+> - **Charge Control C**
+>   - documentation sources at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_control_c
+>   - browse the User Guide at https://chargebyte-docs.readthedocs.io/projects/everest-charge-control-c
+> - **Charge SOM**
+>   - documentation sources at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_som
+>   - browse the User Guide at https://chargebyte-docs.readthedocs.io/projects/everest-charge-som
 
 Contact:
 --------

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Contact:
 
 If you have any questions or inquiries, please contact our support team at https://chargebyte.com/support.
 
-Thank you for using products from chargebyte GmbH!
+Thank you for choosing chargebyte products!

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Welcome to the documentation for products of chargebyte GmbH.
 
 This documentation contains all necessary information and guides for the use and understanding of our products.
 
-Contents:
----------
-
-- Product specifc User Guides and Manuals (In Progress)
-- Developer Documentation (In Progress)
-- FAQs and Troubleshooting (In Progress)
+> [!NOTE]
+> You are on the `main` branch. This does not contain any documentation. 
+>
+> Please refer to either:
+>
+> - **Charge Control C** at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_control_c
+> - **Charge SOM** at https://github.com/chargebyte/chargebyte-docs/tree/everest/charge_som
 
 Contact:
 --------
@@ -18,4 +19,3 @@ Contact:
 If you have any questions or inquiries, please contact our support team at https://chargebyte.com/support.
 
 Thank you for using products from chargebyte GmbH!
-


### PR DESCRIPTION
Also convert to Markdown, as this page will be rendered by GitHub, and RST gets only basic rendering.