### PR TITLE
Update peripheral compatibility list regarding libnfc

### DIFF
--- a/peripheral_compat_list.inc
+++ b/peripheral_compat_list.inc
@@ -176,11 +176,13 @@ RFID Readers
    +-----------------------------------------+-----------+-------------+-------------+--------------------------+----------------------+
    | RFID Readers based on NXP's PN532 Chip  | UART      | Proprietary | `EVerest`_  | `PN532TokenProvider`_    |          ✗           |
    +-----------------------------------------+-----------+-------------+-------------+--------------------------+----------------------+
-   | RFID Readers based on NXP's PN7160 Chip | I²C/SPI   | Proprietary | `EVerest`_  | `PN7160TokenProvider`_   |          ✗           |
-   +-----------------------------------------+-----------+-------------+-------------+--------------------------+----------------------+
 
 .. _PN532TokenProvider: https://github.com/EVerest/everest-core/tree/main/modules/HardwareDrivers/NfcReaders/PN532TokenProvider
 .. _PN7160TokenProvider: https://github.com/EVerest/everest-core/tree/main/modules/HardwareDrivers/NfcReaders/PN7160TokenProvider
+
+.. note::
+   All EVerest modules which depend on libnfc, such as the `PN7160TokenProvider`_, are not officially supported. This library depends on the
+   deprecated GPIO sysfs interface.
 
 
 


### PR DESCRIPTION
The EVerest fork of libnfc doesn't support libgpiod, which is necessary for newer Linux kernels like on Charge SOM. So drop the PN7160TokenProvider from the list of official supported RFID Readers.